### PR TITLE
use the rails way of passing to-commit-callbacks up the xact chain

### DIFF
--- a/lib/after_transaction_commit.rb
+++ b/lib/after_transaction_commit.rb
@@ -8,4 +8,3 @@ require "after_transaction_commit/transaction"
 # force autoloading if necessary
 ActiveRecord::ConnectionAdapters::RealTransaction
 ActiveRecord::ConnectionAdapters::Transaction.prepend(AfterTransactionCommit::Transaction)
-ActiveRecord::ConnectionAdapters::TransactionManager.include(AfterTransactionCommit::TransactionManager)

--- a/lib/after_transaction_commit/database_statements.rb
+++ b/lib/after_transaction_commit/database_statements.rb
@@ -2,8 +2,8 @@
 # classes, so if we include into it, the other classes won't get this method
 ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
   def after_transaction_commit(&block)
-    transaction = transaction_manager.outermost_joinable_transaction
-    return block.call unless transaction
-    transaction.after_transaction_commit(&block)
+    transaction = transaction_manager.current_transaction
+    return block.call unless transaction.joinable?
+    transaction.add_after_commit(block)
   end
 end


### PR DESCRIPTION
this makes it automatically discard callbacks from a more-inner
transaction when a more-outer transaction rolls back